### PR TITLE
Use a different command for scanning on mac.

### DIFF
--- a/commands/scan.go
+++ b/commands/scan.go
@@ -32,12 +32,7 @@ func Scan() cli.Command {
 
 			switch runtime.GOOS {
 			case "darwin":
-				cmd := exec.Command("/bin/sh", "-c", "ls /dev/tty*")
-				cmd.Stdout = os.Stdout
-				cmd.Stderr = os.Stderr
-				cmd.Run()
-
-				cmd = exec.Command("/bin/sh", "-c", "ls /dev/cu*")
+				cmd := exec.Command("/bin/sh", "-c", "ls /dev/{tty,cu}.*")
 				cmd.Stdout = os.Stdout
 				cmd.Stderr = os.Stderr
 				cmd.Run()


### PR DESCRIPTION
`ls /dev/{tty,cu}.*` instead of `ls /dev/cu*` and `ls /dev/tty*`
