### PR TITLE
always show "OS X manages bluetooth ... itself" on OS X

### DIFF
--- a/commands/bluetooth.go
+++ b/commands/bluetooth.go
@@ -27,6 +27,11 @@ func Bluetooth() cli.Command {
 				fmt.Println("gort bluetooth connect <dev> [hciX]\n")
 			}
 
+			if runtime.GOOS == "darwin" {
+				fmt.Println("OS X manages Bluetooth pairing/unpairing/binding itself.")
+				return
+			}
+
 			if valid == false {
 				usage()
 				return
@@ -38,8 +43,6 @@ func Bluetooth() cli.Command {
 			}
 
 			switch runtime.GOOS {
-			case "darwin":
-				fmt.Println("OS X manages Bluetooth pairing/unpairing/binding itself.")
 			case "linux":
 				switch c.Args().First() {
 				case "pair":


### PR DESCRIPTION
Here's a gist of the output before and after this changes: https://gist.github.com/rafmagana/61bb6a4cb8ca42e4a9e8
