### PR TITLE
Fix issue #55 - go digispark install does more than the docs say

### DIFF
--- a/commands/digispark.go
+++ b/commands/digispark.go
@@ -39,7 +39,6 @@ func Digispark() cli.Command {
 			switch c.Args().First() {
 			case "install":
 				downloadDigisparkInstaller()
-				runDigisparkInstaller()
 				return
 
 			case "upload":


### PR DESCRIPTION
Signed-off-by: christophberger <christophberger@users.noreply.github.com>

`gort digispark install` now just downloads the installer (tested locally on macOS).