### PR TITLE
lets run configure and make in a shell

### DIFF
--- a/commands/raspi.go
+++ b/commands/raspi.go
@@ -96,7 +96,7 @@ func raspiInstallPiBlaster() (err error) {
 	}
 
 	fmt.Println("Attempting to build 'pi-blaster'.")
-	cmd = exec.Command("./configure && make")
+	cmd = exec.Command("sh", "-c", "./configure && make")
 	cmd.Dir = fmt.Sprintf("%v/%v", dir, "pi-blaster-master")
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
@@ -105,7 +105,7 @@ func raspiInstallPiBlaster() (err error) {
 	}
 
 	fmt.Println("Attempting to install 'pi-blaster'.")
-	cmd = exec.Command("sudo make install")
+	cmd = exec.Command("sudo", "make", "install")
 	cmd.Dir = fmt.Sprintf("%v/%v", dir, "pi-blaster-master")
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr


### PR DESCRIPTION
&& is a shell feature and not usable in `exec.Command`

```
...
configure.ac:8: installing './missing'
Makefile.am: installing './depcomp'
Preparing was successful if there was no error messages above.
Now type:
  ./configure && make
Run './configure --help' for more information
Attempting to build 'pi-blaster'.
2017/10/09 16:20:50 fork/exec ./configure && make: no such file or directory
```