### PR TITLE
Add support for Arch Linux and Fedora

### DIFF
--- a/commands/arduino.go
+++ b/commands/arduino.go
@@ -84,8 +84,24 @@ func Arduino() cli.Command {
 			case "install":
 				switch runtime.GOOS {
 				case "linux":
-					fmt.Println("Attempting to install avrdude with apt-get...")
-					cmd := exec.Command("sudo", "apt-get", "-y", "install", "avrdude")
+					if linuxCommandExists("avrdude") {
+						return
+					}
+
+					fmt.Println("Attempting to install avrdude")
+					var cmd *exec.Cmd
+					switch getLinuxDist() {
+					case "arch":
+						cmd = exec.Command("sudo", "pacman", "-S", "--noconfirm", "avrdude")
+					case "fedora":
+						cmd = exec.Command("sudo", "yum", "-y", "install", "avrdude")
+					case "ubuntu":
+						cmd = exec.Command("sudo", "apt-get", "-y", "install", "avrdude")
+					default:
+						fmt.Println("Unable to detect Linux distribution. Try installing avrdude manually first")
+						return
+					}
+
 					cmd.Stdout = os.Stdout
 					cmd.Stderr = os.Stderr
 					if err := cmd.Run(); err != nil {

--- a/commands/chip.go
+++ b/commands/chip.go
@@ -166,8 +166,19 @@ func chipBuildAndInstallOverlay(info chipOverlayInfo) (err error) {
 func chipInstallDTC() (err error) {
 	dir, _ := createGortDirectory()
 
-	fmt.Println("Attempting to install dev tools with apt-get.")
-	cmd := exec.Command("sudo", "apt-get", "-y", "install", "flex", "bison", "git")
+	var cmd *exec.Cmd
+
+	fmt.Println("Attempting to install dev tools.")
+	switch getLinuxDist() {
+	case "arch":
+		cmd = exec.Command("sudo", "pacman", "-S", "--noconfirm", "flex", "bison", "git")
+	case "fedora":
+		cmd = exec.Command("sudo", "yum", "-y", "install", "flex", "bison", "git")
+	case "ubuntu":
+		cmd = exec.Command("sudo", "apt-get", "-y", "install", "flex", "bison", "git")
+	default:
+		return fmt.Errorf("Unable to detect Linux distribution. Try installing autoconf manually first")
+	}
 	cmd.Dir = dir
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr

--- a/commands/raspi.go
+++ b/commands/raspi.go
@@ -59,13 +59,26 @@ func Raspi() cli.Command {
 func raspiInstallPiBlaster() (err error) {
 	dir, _ := createGortDirectory()
 
-	fmt.Println("Attempting to install dev tools with apt-get.")
-	cmd := exec.Command("sudo", "apt-get", "-y", "install", "autoconf")
-	cmd.Dir = dir
-	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stderr
-	if err := cmd.Run(); err != nil {
-		log.Fatal(err)
+	var cmd *exec.Cmd
+
+	if !linuxCommandExists("autoconf") {
+		fmt.Println("Attempting to install dev tools")
+		switch getLinuxDist() {
+		case "arch":
+			cmd = exec.Command("sudo", "pacman", "-S", "--noconfirm", "autoconf")
+		case "fedora":
+			cmd = exec.Command("sudo", "yum", "-y", "install", "autoconf")
+		case "ubuntu":
+			cmd = exec.Command("sudo", "apt-get", "-y", "install", "autoconf")
+		default:
+			return fmt.Errorf("Unable to detect Linux distribution. Try installing autoconf manually first")
+		}
+		cmd.Dir = dir
+		cmd.Stdout = os.Stdout
+		cmd.Stderr = os.Stderr
+		if err := cmd.Run(); err != nil {
+			log.Fatal(err)
+		}
 	}
 
 	fmt.Println("Attempting to fetch 'pi-blaster' from github.")

--- a/commands/util.go
+++ b/commands/util.go
@@ -2,15 +2,21 @@ package commands
 
 import (
 	"archive/zip"
+	"bufio"
 	"fmt"
 	"io"
 	"io/ioutil"
 	"log"
 	"net/http"
 	"os"
+	"os/exec"
 	"os/user"
 	"path/filepath"
 	"strings"
+)
+
+var (
+	linuxOSReleasePath = "/etc/os-release"
 )
 
 func exists(path string) (bool, error) {
@@ -139,4 +145,34 @@ func supportDir(support string) (dir string, err error) {
 		}
 	}
 	return
+}
+
+// getLinuxDist returns the name of the running Linux distribution.
+func getLinuxDist() string {
+	f, err := os.Open(linuxOSReleasePath)
+	if err != nil {
+		return ""
+	}
+	defer f.Close()
+
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		ss := strings.SplitN(scanner.Text(), "=", 2)
+
+		if ss[0] == "ID" {
+			return ss[1]
+		}
+	}
+
+	return ""
+}
+
+// linuxCommandExists checks if a command exists on a Linux machine.
+func linuxCommandExists(cmd string) bool {
+	err := exec.Command("/bin/sh", "-c", "command -v "+cmd).Run()
+	if err != nil {
+		return false
+	}
+
+	return true
 }

--- a/commands/util_test.go
+++ b/commands/util_test.go
@@ -1,0 +1,128 @@
+package commands
+
+import (
+	"io/ioutil"
+	"os"
+	"runtime"
+	"testing"
+)
+
+func TestGetLinuxDist(t *testing.T) {
+	tests := map[string]struct {
+		content      []byte
+		writeTmpFile bool
+		expected     string
+	}{
+		"os-release does not exist": {
+			writeTmpFile: false,
+			expected:     "",
+		},
+		"no ID defined": {
+			content: []byte(`
+NAME="Arch Linux"
+PRETTY_NAME="Arch Linux"
+ID_LIKE=archlinux
+ANSI_COLOR="0;36"
+HOME_URL="https://www.archlinux.org/"
+SUPPORT_URL="https://bbs.archlinux.org/"
+BUG_REPORT_URL="https://bugs.archlinux.org/"
+`),
+			writeTmpFile: true,
+			expected:     "",
+		},
+		"Fedora example": {
+			content: []byte(`
+NAME=Fedora
+VERSION="17 (Beefy Miracle)"
+ID=fedora
+VERSION_ID=17
+PRETTY_NAME="Fedora 17 (Beefy Miracle)"
+ANSI_COLOR="0;34"
+CPE_NAME="cpe:/o:fedoraproject:fedora:17"
+HOME_URL="https://fedoraproject.org/"
+BUG_REPORT_URL="https://bugzilla.redhat.com/"
+`),
+			writeTmpFile: true,
+			expected:     "fedora",
+		},
+		"Ubuntu example": {
+			content: []byte(`
+NAME="Ubuntu"
+VERSION="13.10, Saucy Salamander"
+ID=ubuntu
+ID_LIKE=debian
+PRETTY_NAME="Ubuntu 13.10"
+VERSION_ID="13.10"
+HOME_URL="http://www.ubuntu.com/"
+SUPPORT_URL="http://help.ubuntu.com/"
+BUG_REPORT_URL="http://bugs.launchpad.net/ubuntu/"
+`),
+			writeTmpFile: true,
+			expected:     "ubuntu",
+		},
+		"Arch Linux example": {
+			content: []byte(`
+NAME="Arch Linux"
+PRETTY_NAME="Arch Linux"
+ID=arch
+ID_LIKE=archlinux
+ANSI_COLOR="0;36"
+HOME_URL="https://www.archlinux.org/"
+SUPPORT_URL="https://bbs.archlinux.org/"
+BUG_REPORT_URL="https://bugs.archlinux.org/"
+`),
+			writeTmpFile: true,
+			expected:     "arch",
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			tmp := linuxOSReleasePath
+
+			if test.writeTmpFile {
+				f, err := ioutil.TempFile(os.TempDir(), "linuxdist")
+				if err != nil {
+					t.Fatalf("Expected nil, got %s", err.Error())
+				}
+
+				f.Write(test.content)
+				defer os.Remove(f.Name())
+				defer f.Close()
+
+				linuxOSReleasePath = f.Name()
+			} else {
+				linuxOSReleasePath = "/does/not/exist"
+			}
+			defer func() { linuxOSReleasePath = tmp }()
+
+			dist := getLinuxDist()
+			if dist != test.expected {
+				t.Errorf("Expected %s, got %s", test.expected, dist)
+			}
+		})
+	}
+}
+
+func TestLinuxCommandExists(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skipf("skipping test for platform %s", runtime.GOOS)
+	}
+
+	tests := map[string]struct {
+		cmd      string
+		expected bool
+	}{
+		"command exists":         {cmd: "true", expected: true},
+		"command does not exist": {cmd: "does_not_exist", expected: false},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			exists := linuxCommandExists(test.cmd)
+			if exists != test.expected {
+				t.Errorf("Expected %t, got %t", test.expected, exists)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This pull request is adding support for installing required packages for Arch Linux and Fedora. It also adds a coupld of utils that can be used to detect Linux distribution and whether or not a binary is already installed.